### PR TITLE
The delimiter when was used as property of class did not work

### DIFF
--- a/src/Crockett/CsvSeeder/CsvSeeder.php
+++ b/src/Crockett/CsvSeeder/CsvSeeder.php
@@ -174,7 +174,7 @@ class CsvSeeder extends Seeder
         $filename = null,
         $table = null,
         $model = null,
-        $delimiter = ',',
+        $delimiter = null,
         $mapping = null,
         $aliases = null,
         $insert_callback = null
@@ -197,7 +197,7 @@ class CsvSeeder extends Seeder
         $filename = null,
         $table = null,
         $model = null,
-        $delimiter = ',',
+        $delimiter = null,
         $aliases = null,
         $mapping = null,
         $insert_callback = null

--- a/src/Crockett/CsvSeeder/CsvSeeder.php
+++ b/src/Crockett/CsvSeeder/CsvSeeder.php
@@ -208,7 +208,7 @@ class CsvSeeder extends Seeder
         $this->delimiter       = $delimiter ?: $this->delimiter;
         $this->aliases         = $aliases ?: $this->aliases;
         $this->mapping         = $mapping ?: $this->mapping;
-        $this->insert_callback = $insert_callback;
+        $this->insert_callback = $insert_callback ?: $this->insert_callback ; 
 
         $this->runSeeder();
     }


### PR DESCRIPTION
Because was defined as a intern hard coded method parameter.