### PR TITLE
allows row parser to accept 0 integer values instead of replacing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /vendor
 composer.phar
 composer.lock

--- a/src/Crockett/CsvSeeder/CsvSeeder.php
+++ b/src/Crockett/CsvSeeder/CsvSeeder.php
@@ -517,7 +517,7 @@ class CsvSeeder extends Seeder
         $columns = new Collection();
         // apply mapping to a given row
         foreach ($mapping as $csv_index => $column_name) {
-            $column_value = ( array_key_exists($csv_index, $row) && !empty( $row[$csv_index] ) )
+            $column_value = ( array_key_exists($csv_index, $row) && isset( $row[$csv_index] ) && $row[$csv_index] !== '')
                 ? $row[$csv_index]
                 : null;
             $columns->put($column_name, $column_value);


### PR DESCRIPTION
The row parser will assign NULL to 0 integer values.  !empty will return TRUE for 0 integers, so isset is used instead, and then evaluated against empty strings to preserve "true" NULL values. 